### PR TITLE
Set encoding of bytes function

### DIFF
--- a/ahvl/lookup.py
+++ b/ahvl/lookup.py
@@ -167,19 +167,19 @@ class AhvlLookup(LookupBase):
 
     def return_pbkdf2sha256(self, secret, options):
         from passlib.hash import pbkdf2_sha256
-        return pbkdf2_sha256.hash(secret, salt=bytes(self.find_salt(options)))
+        return pbkdf2_sha256.hash(secret, salt=bytes(self.find_salt(options), encoding='utf8'))
 
     def return_pbkdf2sha512(self, secret, options):
         from passlib.hash import pbkdf2_sha512
-        return pbkdf2_sha512.hash(secret, salt=bytes(self.find_salt(options)), rounds=58000)
+        return pbkdf2_sha512.hash(secret, salt=bytes(self.find_salt(options), encoding='utf8'), rounds=58000)
 
     def return_argon2(self, secret, options):
         from passlib.hash import argon2
-        return argon2.using(salt=bytes(self.find_salt(options)), rounds=32).hash(secret)
+        return argon2.using(salt=bytes(self.find_salt(options), encoding='utf8'), rounds=32).hash(secret)
 
     def return_grubpbkdf2sha512(self, secret, options):
         from passlib.hash import grub_pbkdf2_sha512
-        return grub_pbkdf2_sha512.hash(secret, salt=bytes(self.find_salt(options)), rounds=38000)
+        return grub_pbkdf2_sha512.hash(secret, salt=bytes(self.find_salt(options), encoding='utf8'), rounds=38000)
 
     #
     # find salt


### PR DESCRIPTION
Fixes the errors complaining about the bytes function missing an encoding argument,
such as:

```
fatal: [localhost]: FAILED! => {"msg": "An unhandled exception occurred while running the lookup plugin 'ahvl_password'. Error was a <class 'TypeError'>, original message: string argument without an encoding"}
```